### PR TITLE
Added functionality for matching longest prefix from trie

### DIFF
--- a/trie.js
+++ b/trie.js
@@ -80,6 +80,29 @@ var Trie = function() {
 	};
 	
 	/**
+	 * Get longest matching prefix
+	 */
+	self.getLongestPrefix = function(word) {
+ 	    if (typeof word !== 'string' || ! word.length) {return false;}
+ 	    var result = "", prevString = ""
+ 	    var current = dictionary;
+ 			for (var i = 0, c = word.length; i < c; i++) {
+ 				if (! current[word[i]]) {
+ 					break;
+ 				}
+ 				result += word[i];
+ 	      current = current[word[i]];
+ 	      if(current[FLAG_INDEX] === 1){
+ 	         prevString = result
+ 	      }
+ 			}
+ 	    if(current[FLAG_INDEX] !== 1){
+ 	       return prevString
+ 	    }
+ 	    return result
+ 	};
+	
+	/**
 	 * Get a string representation of the trie structure
 	 */
 	self.dumpJson = function() {


### PR DESCRIPTION
This function will find the longest matching string efficiently from trie.
eg : 
 if we insert "91" and "919" and we want to find longest matching string for "919324" then it will give "919" as the result.